### PR TITLE
specify files to pack to avoid oclif warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "A heroku plugin to display differences between app environments.",
   "main": "index.js",
   "author": "Maciek Sakrejda",
-  "repository": "uhoh-itsmaciek/heroku-run-localjs",
+  "repository": "uhoh-itsmaciek/heroku-config-diff",
   "bugs": {
-    "url": "https://github.com/uhoh-itsmaciek/heroku-run-localjs/issues"
+    "url": "https://github.com/uhoh-itsmaciek/heroku-config-diff/issues"
   },
   "keywords": [
     "heroku-plugin"
@@ -20,6 +20,10 @@
   "scripts": {
     "test": "eslint index.js commands/"
   },
+  "files": [
+    "/index.js",
+    "/commands"
+  ],
   "devDependencies": {
     "chai": "*",
     "eslint": "*",


### PR DESCRIPTION
this attribute is now required in plugins otherwise a warning is displayed (though notably, the plugins still work fine with the warning)

See my blog post for the reason why this is now required: https://medium.com/@jdxcode/for-the-love-of-god-dont-use-npmignore-f93c08909d8d

for other plugins, if you run `npm pack; tar -xvzf *.tgz; rm -rf package *.tgz` that will print the files it's currently packing